### PR TITLE
Add unique id to tooltips

### DIFF
--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -47,6 +47,7 @@ interface Props extends TooltipProps {
 }
 
 export const Tooltip: React.FunctionComponent<Props> = (props: Props) => {
+  const id = useId('tooltip')
   return (
     <>
       <Wrapper
@@ -58,6 +59,7 @@ export const Tooltip: React.FunctionComponent<Props> = (props: Props) => {
             : `${props.title}`
         }
         data-html={true}
+        data-for={id}
         data-place={props.place || 'bottom'}
         cursor={props.cursor || 'help'}
       >
@@ -65,6 +67,7 @@ export const Tooltip: React.FunctionComponent<Props> = (props: Props) => {
       </Wrapper>
 
       <StyledTooltip
+        id={id}
         effect="solid"
         multiline={true}
         arrowColor="transparent"
@@ -74,6 +77,26 @@ export const Tooltip: React.FunctionComponent<Props> = (props: Props) => {
       />
     </>
   )
+}
+
+let serverHandoffComplete = false;
+let i = 0;
+const genId = () => ++i
+
+function useId(prefix = '') {
+  const initialId = serverHandoffComplete ? genId() : null
+
+  const [id, setId] = React.useState(initialId)
+
+  React.useEffect(() => {
+    serverHandoffComplete = true
+
+    if (id === null) {
+      setId(genId())
+    }
+  }, []);
+
+  return id != null ? prefix.concat(id) : undefined
 }
 
 export default Tooltip

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -79,8 +79,8 @@ export const Tooltip: React.FunctionComponent<Props> = (props: Props) => {
   )
 }
 
-let serverHandoffComplete = false;
-let i = 0;
+let serverHandoffComplete = false
+let i = 0
 const genId = () => ++i
 
 function useId(prefix = '') {
@@ -94,7 +94,7 @@ function useId(prefix = '') {
     if (id === null) {
       setId(genId())
     }
-  }, []);
+  }, [])
 
   return id != null ? prefix.concat(id) : undefined
 }


### PR DESCRIPTION
Because react-tooltip uses the `data-tip` property to find tooltip content, if there's more than one tooltip on the page it can cause duplicate tooltips. This adds a unique id to each tooltip to prevent that.