### PR TITLE
Change display field copy icon

### DIFF
--- a/packages/display-field/src/CopyIcon.tsx
+++ b/packages/display-field/src/CopyIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export default ({ size }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z"
+      stroke="black"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5"
+      stroke="black"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-dasharray="2 2"
+    />
+  </svg>
+)

--- a/packages/display-field/src/DisplayField.tsx
+++ b/packages/display-field/src/DisplayField.tsx
@@ -5,9 +5,13 @@ import { Anchor, AnchorProps, Box, BoxProps, Text, TextProps } from 'grommet'
 import { MarginType, PolymorphicType } from 'grommet/utils'
 import { copyToClipboard } from '@centrifuge/axis-utils'
 import { Copy, Icon } from 'grommet-icons'
+import CopyIcon from './CopyIcon'
 
 // Define type for theme props
 interface ThemeProps {
+  icon: {
+    size: Record<string, string>
+  }
   displayField: {
     labelBox?: BoxProps
     labelText?: TextProps
@@ -72,8 +76,12 @@ export const DisplayField: React.FunctionComponent<Props> = ({
   theme,
 }) => {
   const {
+    icon,
     displayField: { labelBox, labelText, anchor, icons },
   } = theme
+
+  // get icon size from Grommet config
+  const iconSize = icon.size[icons.size || ''] || icons.size || '24'
 
   const WithLink = ({ link, children }) => {
     return link ? (
@@ -109,7 +117,7 @@ export const DisplayField: React.FunctionComponent<Props> = ({
           }}
           title={'Copy to clipboard'}
         >
-          <icons.copy size={icons.size} />
+          <CopyIcon size={iconSize} />
         </Anchor>
       </Box>
     ) : (

--- a/packages/display-field/src/DisplayField.tsx
+++ b/packages/display-field/src/DisplayField.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import styled, { ThemeProps as StyledThemeProps, withTheme } from 'styled-components'
 import { defaultProps, extendDefaultTheme } from 'grommet/default-props'
 import { Anchor, AnchorProps, Box, BoxProps, Text, TextProps } from 'grommet'
-import { MarginType, PolymorphicType } from 'grommet/utils'
+import { PolymorphicType } from 'grommet/utils'
 import { copyToClipboard } from '@centrifuge/axis-utils'
-import { Copy, Icon } from 'grommet-icons'
 import CopyIcon from './CopyIcon'
 
 // Define type for theme props
@@ -18,8 +17,6 @@ interface ThemeProps {
     anchor?: AnchorProps
     extend?: (props) => string
     icons: {
-      copy: Icon
-      margin?: MarginType
       size?: 'small' | 'medium' | 'large' | 'xlarge' | string
     }
   }
@@ -152,7 +149,6 @@ export const defaultThemeProps: ThemeProps = {
       color: 'brand',
     },
     icons: {
-      copy: Copy,
       size: 'small',
     },
   },


### PR DESCRIPTION
Needed for https://github.com/centrifuge/apps/issues/363

## Before (Grommet icon)

![Screenshot 2021-09-08 at 15 32 59](https://user-images.githubusercontent.com/8630331/132519237-bff76ed3-b7f5-4728-b1ac-301556e9c558.png)

## After (custom icon)

![Screenshot 2021-09-08 at 15 33 10](https://user-images.githubusercontent.com/8630331/132519333-212ad6bb-1483-4eb3-bc6a-d017639a2724.png)
